### PR TITLE
Add more support to table stepper buttons

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,4 @@
 # Default ignored files
 /shelf/
 /workspace.xml
+../target

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_15" default="true" project-jdk-name="openjdk-15" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: main.java.MainClass
+

--- a/src/main/java/FileFormatException.java
+++ b/src/main/java/FileFormatException.java
@@ -1,3 +1,5 @@
+package main.java;
+
 public class FileFormatException extends Exception{
     public FileFormatException(){
         super("Invalid formatting in file.\n- File must have a .txt or .csv file");

--- a/src/main/java/IllegalFileContentsException.java
+++ b/src/main/java/IllegalFileContentsException.java
@@ -1,3 +1,5 @@
+package main.java;
+
 public class IllegalFileContentsException extends Exception {
     public IllegalFileContentsException(){
         super("File must contain parsable, real numbers");

--- a/src/main/java/IllegalTableContentsException.java
+++ b/src/main/java/IllegalTableContentsException.java
@@ -1,3 +1,5 @@
+package main.java;
+
 public class IllegalTableContentsException extends Exception {
     public IllegalTableContentsException(){
         super("Table contains non-parsable data.");

--- a/src/main/java/InvalidNOrHException.java
+++ b/src/main/java/InvalidNOrHException.java
@@ -1,3 +1,5 @@
+package main.java;
+
 public class InvalidNOrHException extends Exception {
     public InvalidNOrHException(){
         super("Invalid values for N or H.\n- N must be an integer\n- H must be an integer, decimal, or a fraction\n- N and H must be positive");

--- a/src/main/java/MainClass.java
+++ b/src/main/java/MainClass.java
@@ -1,3 +1,5 @@
+package main.java;
+
 // Java Swing objects
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -192,23 +194,37 @@ public class MainClass{
             }
         });
 
-        JButton addRow = new JButton(new AbstractAction("+") {
+        JButton addRow = new JButton(new AbstractAction("Add Row") {
             @Override
             public void actionPerformed(ActionEvent e) {
-                if (tableModel.getRowCount() <50)
-                    tableModel.addRow(new String[]{"", ""});
-                else
+                if (table.getSelectedRow() == -1)
+                    JOptionPane.showMessageDialog(frame, "Please select a row.");
+                else if (tableModel.getRowCount() == 50)
                     JOptionPane.showMessageDialog(frame, "You have exceeded the maximum rows (50 rows).");
+                else
+                    tableModel.insertRow(table.getSelectedRow()+1, new String[]{"", ""});
             }
         });
 
-        JButton deleteRow = new JButton(new AbstractAction("-") {
+        JButton deleteRow = new JButton(new AbstractAction("Delete Row") {
             @Override
             public void actionPerformed(ActionEvent e) {
-                if (tableModel.getRowCount() > 3)
-                    tableModel.removeRow(tableModel.getRowCount()-1);
-                else
+                if (table.getSelectedRow() == -1)
+                    JOptionPane.showMessageDialog(frame, "Please select a row.");
+                else if (tableModel.getRowCount() == 3)
                     JOptionPane.showMessageDialog(frame, "You must have at least 3 data points.");
+                else
+                    tableModel.removeRow(table.getSelectedRow());
+            }
+        });
+
+        JButton pushDown = new JButton(new AbstractAction("Push Down") {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (tableModel.getRowCount() >= 50)
+                    JOptionPane.showMessageDialog(frame, "You have exceeded the maximum rows (50 rows).");
+                else
+                    tableModel.insertRow(0, new String[]{"", ""});
             }
         });
 
@@ -345,9 +361,10 @@ public class MainClass{
         dataPanel.add(pane, constraints);
 
         // Stepper
-        JPanel stepper = new JPanel(new GridLayout(3, 1));
+        JPanel stepper = new JPanel(new GridLayout(4, 1));
         stepper.add(addRow);
         stepper.add(deleteRow);
+        stepper.add(pushDown);
         stepper.add(clearData);
         constraints.gridx = 1;
         constraints.gridy = 0;

--- a/src/main/java/NumericalIntegration.java
+++ b/src/main/java/NumericalIntegration.java
@@ -1,3 +1,5 @@
+package main.java;
+
 import java.util.ArrayList;
 
 public class NumericalIntegration {

--- a/src/main/java/SimpsonsRuleException.java
+++ b/src/main/java/SimpsonsRuleException.java
@@ -1,3 +1,5 @@
+package main.java;
+
 public class SimpsonsRuleException extends Exception{
     public SimpsonsRuleException(){
         super("N must be even when applying Simpson's Rule.");

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,2 @@
 Manifest-Version: 1.0
-Main-Class: MainClass
+Main-Class: main.java.MainClass


### PR DESCRIPTION
In this pull request, I added more support to the table stepper buttons. 

The "Add Row" button can now add a row right below the row selected by the user.
The "Delete Row" button can now remove the row selected by the user.
The "Push Down" button can push all the rows down one.

All of these actions are possible as long as the table has 3 to 50 rows. 